### PR TITLE
[#22] Document Difference Between randomIO & nextRandom

### DIFF
--- a/uuid-types/Data/UUID/Types/Internal.hs
+++ b/uuid-types/Data/UUID/Types/Internal.hs
@@ -72,9 +72,9 @@ import System.Random
 
 
 -- |The UUID type.  A 'Random' instance is provided which produces
--- version 4 UUIDs as specified in RFC 4122.  The 'Storable' and
--- 'Binary' instances are compatible with RFC 4122, storing the fields
--- in network order as 16 bytes.
+-- insecure version 4 UUIDs as specified in RFC 4122.  The 'Storable' and
+-- 'Binary' instances are compatible with RFC 4122, storing the fields in
+-- network order as 16 bytes.
 data UUID
     = UUID
          {-# UNPACK #-} !Word32

--- a/uuid/Data/UUID.hs
+++ b/uuid/Data/UUID.hs
@@ -14,8 +14,9 @@ printing Universally Unique Identifiers.
 See <http://en.wikipedia.org/wiki/UUID> for the general idea.
 See <http://tools.ietf.org/html/rfc4122> for the specification.
 
-* Random UUIDs may be generated using 'Data.UUID.V4.nextRandom' or
-your favorite instance of 'System.Random.Random'.
+* Use 'Data.UUID.V4.nextRandom' to generate secure random UUIDs, and your
+favorite instance of 'System.Random.Random' for faster but insecure
+generation of UUIDs.
 
 * We have an implementation of generating a UUID from the hardware
 MAC address and current system time in "Data.UUID.V1".

--- a/uuid/Data/UUID/V4.hs
+++ b/uuid/Data/UUID/V4.hs
@@ -26,7 +26,8 @@ import Data.UUID.Types.Internal ( buildFromBytes )
 import System.Entropy ( getEntropy )
 import Data.ByteString ( unpack )
 
--- | Generate a random UUID. Introduced in version 1.2.6.
+-- | Generate a crytographically secure, random UUID. Introduced in version
+-- 1.2.6.
 nextRandom :: IO UUID
 nextRandom = do
   [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, ba, bb, bc, bd, be, bf]


### PR DESCRIPTION
The `Random` class should be used for UUIDs where cryptographic security
is not necessary, while `Data.UUID.v4.nextRandom` should be used for
UUIDs that need to be cryptographically secure.

Refs #22


Let me know if I should change anything. Also wasn't sure if I should bump the copyright years in the respect files.